### PR TITLE
Introduce SIGINT handler and SO_REUSEADDR socket option

### DIFF
--- a/include/server.hpp
+++ b/include/server.hpp
@@ -1,6 +1,8 @@
 #ifndef SERVER_HPP
 #define SERVER_HPP
 
+#include <atomic>
+#include <csignal>
 #include <cstdint>
 
 #include "constants.hpp"
@@ -14,7 +16,9 @@
  */
 class Server {
 private:
-    SOCKET_FD ss;
+    SOCKET_FD         ss;
+    std::atomic<bool> stop_flag;
+    static Server*    me;
 
 public:
     Server();
@@ -34,6 +38,15 @@ public:
      * @param router Reference to the router
      */
     void start(std::uint16_t port, Router& router);
+
+    void handle_signal();
+
+private:
+    static void signal_handler(int signum) {
+        if (signum == SIGINT) {
+            me->handle_signal();
+        }
+    }
 };
 
 #endif  // !SERVER_HPP

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -17,7 +17,6 @@
 #include <memory>
 #include <string>
 #include "constants.hpp"
-#include "logger.hpp"
 #include "req-parser.hpp"
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,9 @@
-#include <iostream>
 #include "constants.hpp"
 #include "request.hpp"
 #include "router.hpp"
 #include "server.hpp"
+
+#define port 5000
 
 void hello_world(const Request& req, Response& res) {
     res.send("Hello, world from controller function!!").status(OK);
@@ -15,9 +16,6 @@ void init_router(Router& router) {
 }
 
 int main() {
-    std::uint16_t port = 0;
-    std::cin >> port;
-
     Router router;
     init_router(std::ref(router));
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4,14 +4,22 @@
  */
 
 #include "server.hpp"
+#include <arpa/inet.h>
+#include <asm-generic/socket.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
 #include <unistd.h>
+#include <csignal>
 #include <functional>
 #include <thread>
 #include "dispatcher.hpp"
 #include "logger.hpp"
 
-Server::Server() : ss(-1) {}
+Server* Server::me = nullptr;
+
+Server::Server() : ss(-1), stop_flag(false) {
+    Server::me = this;
+}
 
 Server::~Server() {
     if (this->ss != -1) {
@@ -34,34 +42,66 @@ void Server::start(std::uint16_t port, Router& router) {
         SafeLogger::log(errno);
         return;
     }
+    this->ss = server_socket;
+
+    int optval = 1;
+    if (setsockopt(server_socket, SOL_SOCKET, SO_REUSEADDR, &optval,
+                   sizeof(optval)) < 0) {
+        SafeLogger::log(errno);
+        close(server_socket);
+        return;
+    }
+
+    struct sigaction a {};
+    a.sa_handler = Server::signal_handler;
+    a.sa_flags   = 0;
+    sigemptyset(&a.sa_mask);
+    sigaction(SIGINT, &a, NULL);
 
     if (bind(server_socket, (struct sockaddr*)&address, sizeof(address)) ==
         -1) {
         SafeLogger::log(errno);
+        close(server_socket);
         return;
     }
 
     // start listening
     if (listen(server_socket, 10) == -1) {
         SafeLogger::log(errno);
+        close(server_socket);
         return;
     }
 
-    ;
     SafeLogger::log("Server listening on port " + std::to_string(port));
+
+    struct sockaddr_in client_addr {};
+    socklen_t          client_len = sizeof(client_addr);
 
     // server loop
     // let dispatcher take over request
-    while (true) {
-        SOCKET_FD new_socket = accept(server_socket, nullptr, nullptr);
+    while (!this->stop_flag.load()) {
+        // accept connection
+        SOCKET_FD new_socket =
+            accept(server_socket, (struct sockaddr*)&client_addr, &client_len);
         if (new_socket == -1) {
             SafeLogger::log(errno);
             continue;
         }
+
+        std::string client_ip   = inet_ntoa(client_addr.sin_addr);
+        std::string client_port = std::to_string(ntohs(client_addr.sin_port));
+        SafeLogger::log("Connection accepted from " + client_ip + ":" +
+                        client_port);
 
         std::thread dispatcher =
             std::thread(take_over, new_socket, std::ref(router));
 
         dispatcher.detach();
     }
+    close(this->ss);
+    this->ss = -1;
+}
+
+void Server::handle_signal() {
+    this->stop_flag.store(true);
 }


### PR DESCRIPTION
closes #16 

Introducing SIGINT handler didn't fix the issue, so we set SO_REUSEADDR option for the socket, which now allows server to be started right after closing it, fixing "address already in the use" issue