### PR TITLE
Introduce SO_RCVTIMEO option for clients socket

### DIFF
--- a/include/dispatcher.hpp
+++ b/include/dispatcher.hpp
@@ -8,7 +8,7 @@ constexpr int     REQ_BUF_SIZE = 4096;
 constexpr int     MAX_RETRIES  = 2;  // Maximum number of retries to get headers
 constexpr int     SLEEP_TIME_MS    = 500;  // Sleep time in milliseconds
 constexpr ssize_t MAX_HEADERS_SIZE = 16384;
-constexpr size_t  MAX_BODY_SIZE    = 16384;
+constexpr ssize_t MAX_BODY_SIZE    = 16384;
 
 /**
  * @brief The dispatcher function to handle incoming requests.


### PR DESCRIPTION
closes #21 

Introduced SO_RCVTIMEO option for clients socket, this way we will just timeout client if he doesn't send data instead of waiting for data forever.

Fixed bugs with data types in recv_body() as well